### PR TITLE
Add multi-row support to PCopy feature

### DIFF
--- a/src/main/java/com/screenshort/utils/CustomMessageEditorHotKey.java
+++ b/src/main/java/com/screenshort/utils/CustomMessageEditorHotKey.java
@@ -1,5 +1,6 @@
 package com.screenshort.utils;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import burp.api.montoya.MontoyaApi;
@@ -34,10 +35,34 @@ public class CustomMessageEditorHotKey {
                 evt -> screenshotUtils.handleFullScreenshot()
         );
 
-        // PCopy hotkeys - using helper method to reduce duplication
-        registerRequestResponseHotKey(api, "Ctrl+Alt+Space", menuHandler::handleCopyToExcel);
-        registerRequestResponseHotKey(api, "Ctrl+Alt+X", menuHandler::handleCopyToExcelNoBody);
+        // PCopy hotkeys - using helper method to reduce duplication (supports list)
+        registerRequestResponseListHotKey(api, "Ctrl+Alt+Space", menuHandler::handleCopyToExcel);
+        registerRequestResponseListHotKey(api, "Ctrl+Alt+X", menuHandler::handleCopyToExcelNoBody);
+
+        // GenData hotkey - single item
         registerRequestResponseHotKey(api, "Ctrl+Alt+V", menuHandler::handleGenDataAction);
+    }
+
+    /**
+     * Helper method to register a hotkey that requires List of HttpRequestResponse.
+     * Used for PCopy which supports multiple selections.
+     *
+     * @param api     The Montoya API
+     * @param hotkey  The hotkey combination string
+     * @param handler The handler to invoke with the List of HttpRequestResponse
+     */
+    private void registerRequestResponseListHotKey(
+            MontoyaApi api,
+            String hotkey,
+            Consumer<List<HttpRequestResponse>> handler
+    ) {
+        api.userInterface().registerHotKeyHandler(
+                HotKeyContext.HTTP_MESSAGE_EDITOR,
+                hotkey,
+                evt -> evt.messageEditorRequestResponse()
+                        .map(m -> m.requestResponse())
+                        .ifPresent(reqRes -> handler.accept(List.of(reqRes)))
+        );
     }
 
     /**

--- a/src/main/java/com/screenshort/utils/ExcelFormatterUtils.java
+++ b/src/main/java/com/screenshort/utils/ExcelFormatterUtils.java
@@ -274,6 +274,27 @@ public final class ExcelFormatterUtils {
     }
 
     /**
+     * Formats multiple HttpRequestResponse for Excel with full body content.
+     * Each row is separated by newline for multi-row paste in Excel.
+     *
+     * @param requestResponses The list of request/response data
+     * @return Tab-separated string with multiple rows ready for Excel paste
+     */
+    public static String formatRequestResponseForExcel(List<HttpRequestResponse> requestResponses) {
+        if (requestResponses == null || requestResponses.isEmpty()) {
+            return "";
+        }
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < requestResponses.size(); i++) {
+            if (i > 0) {
+                result.append("\n");
+            }
+            result.append(formatRequestResponse(requestResponses.get(i), true));
+        }
+        return result.toString();
+    }
+
+    /**
      * Formats HttpRequestResponse for Excel with body content redacted.
      *
      * @param requestResponse The request/response data
@@ -281,6 +302,27 @@ public final class ExcelFormatterUtils {
      */
     public static String formatRequestResponseForExcelNoBody(HttpRequestResponse requestResponse) {
         return formatRequestResponse(requestResponse, false);
+    }
+
+    /**
+     * Formats multiple HttpRequestResponse for Excel with body content redacted.
+     * Each row is separated by newline for multi-row paste in Excel.
+     *
+     * @param requestResponses The list of request/response data
+     * @return Tab-separated string with multiple rows ready for Excel paste
+     */
+    public static String formatRequestResponseForExcelNoBody(List<HttpRequestResponse> requestResponses) {
+        if (requestResponses == null || requestResponses.isEmpty()) {
+            return "";
+        }
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < requestResponses.size(); i++) {
+            if (i > 0) {
+                result.append("\n");
+            }
+            result.append(formatRequestResponse(requestResponses.get(i), false));
+        }
+        return result.toString();
     }
 
     /**

--- a/src/main/java/com/screenshort/utils/MenuActionHandler.java
+++ b/src/main/java/com/screenshort/utils/MenuActionHandler.java
@@ -26,24 +26,24 @@ public class MenuActionHandler {
 
 
     // --- Other utility methods (unchanged) ---
-    public void handleCopyToExcel(HttpRequestResponse requestResponse) {
-        if (requestResponse == null) {
-             api.logging().logToOutput("Cannot copy to Excel: RequestResponse is null.");
+    public void handleCopyToExcel(List<HttpRequestResponse> requestResponses) {
+        if (requestResponses == null || requestResponses.isEmpty()) {
+             api.logging().logToOutput("Cannot copy to Excel: No RequestResponse selected.");
              return;
         }
-        // Assume ExcelFormatterUtils exists and works
-        String data = ExcelFormatterUtils.formatRequestResponseForExcel(requestResponse);
+        String data = ExcelFormatterUtils.formatRequestResponseForExcel(requestResponses);
         ExcelFormatterUtils.copyToClipboard(data);
+        api.logging().logToOutput("PCopy: Copied " + requestResponses.size() + " row(s) to clipboard.");
     }
 
-    public void handleCopyToExcelNoBody(HttpRequestResponse requestResponse) {
-         if (requestResponse == null) {
-             api.logging().logToOutput("Cannot copy to Excel: RequestResponse is null.");
+    public void handleCopyToExcelNoBody(List<HttpRequestResponse> requestResponses) {
+        if (requestResponses == null || requestResponses.isEmpty()) {
+             api.logging().logToOutput("Cannot copy to Excel: No RequestResponse selected.");
              return;
         }
-         // Assume ExcelFormatterUtils exists and works
-         String data = ExcelFormatterUtils.formatRequestResponseForExcelNoBody(requestResponse);
-         ExcelFormatterUtils.copyToClipboard(data);
+        String data = ExcelFormatterUtils.formatRequestResponseForExcelNoBody(requestResponses);
+        ExcelFormatterUtils.copyToClipboard(data);
+        api.logging().logToOutput("PCopy: Copied " + requestResponses.size() + " row(s) to clipboard (no body).");
     }
     public void handleGenDataAction(HttpRequestResponse requestResponse) {
         if (requestResponse == null) {


### PR DESCRIPTION
PCopy now supports copying multiple selected request/response pairs at once:

- ExcelFormatterUtils: Add overloaded methods that accept List<HttpRequestResponse>
  and format multiple rows separated by newlines
- MenuActionHandler: Update handleCopyToExcel/handleCopyToExcelNoBody to accept List<HttpRequestResponse> and log the number of rows copied
- GUI.java: Update provideMenuItems to pass all selected items to PCopy menu (shows item count in menu label when multiple items selected)
- CustomMessageEditorHotKey: Add registerRequestResponseListHotKey helper for PCopy hotkeys to work with lists

Usage: Select multiple rows in Burp's HTTP history, right-click and use PCopy to copy all selected items as multiple Excel rows.
